### PR TITLE
Handle pagination of log groups for orgs with more than 50 logs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -213,16 +213,16 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 
 			regionToLogGroupsMap[region] =
-					_(logGroups).
-						map(logGroup => new RegExp(`^${logGroup.replace(/\*/g, '.*')}$`, "i")).
-						flatMap(
-							logGroupRegex =>
-								_.filter(
-									responseGroupCache[cacheKey],
-									logGroup => logGroupRegex.test(logGroup.logGroupName ?? ""))).
-						map(logGroup => logGroup.logGroupName!).
-						uniq().
-						value();
+				_(logGroups).
+					map(logGroup => new RegExp(`^${logGroup.replace(/\*/g, '.*')}$`, "i")).
+					flatMap(
+						logGroupRegex =>
+							_.filter(
+								responseGroupCache[cacheKey],
+								logGroup => logGroupRegex.test(logGroup.logGroupName ?? ""))).
+					map(logGroup => logGroup.logGroupName!).
+					uniq().
+					value();
 		}
 
 		const regionToStartQueryIdMap: { [x: string]: string } = {};
@@ -303,7 +303,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 					if (fields.length > 0) {
 						const newFieldExists = !unorderedEquals(fields, query.queryResultsFieldNames ?? []);
-                        if (newFieldExists) {
+						if (newFieldExists) {
 							query.queryResultsFieldNames = fields;
 						}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -242,7 +242,7 @@ export function activate(context: vscode.ExtensionContext) {
 				regionToStartQueryIdMap[region] = startQueryResponse.queryId!;
 			}
 			catch (error) {
-                const awsError = <AWSError>error;
+				const awsError = <AWSError>error;
 				vscode.window.showErrorMessage(`${awsError.name}, error: ${awsError.message}`);
 				return;
 			}


### PR DESCRIPTION
This extension is awesome but it does not work for us because we have way more than 50 log groups. The describeLogGroups call limits the response to 50 log groups per request, so to load all of them you need to handle pagination. This PR adds pagination support to the describeLogGroups, and to keep future requests performant it caches them by environment and region. I have tested this with my companies logs and they work. Without this change I cannot use the extension because the describeLogGroups call never finds my teams' log group, so the query call to AWS always fails.

Would kindly appreciate this being merged so we can use the extension :). Also, while I was in the code, I fixed a number of linting errors which VS Code was complaining about.